### PR TITLE
use actual file exists check

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -38,7 +38,7 @@ function plugin(opts){
       if (!~exts.indexOf(ext)) throw new Error('unsupported metadata type "' + ext + '"');
       var filepath = metalsmith.dir + '/' + metalsmith._src + '/' + file;
       var exists = fs.existsSync(filepath);
-      if (! exists) throw new Error('file "' + file + '" not found');
+      if (! exists) throw new Error('file "' + filepath + '" not found');
 
       var parse = parsers[ext];
       var str = files[file].contents.toString();

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,7 @@
 
 var extname = require('path').extname;
 var yaml = require('js-yaml');
+var fs = require('fs');
 
 /**
  * Expose `plugin`.
@@ -35,7 +36,9 @@ function plugin(opts){
       var file = opts[key];
       var ext = extname(file);
       if (!~exts.indexOf(ext)) throw new Error('unsupported metadata type "' + ext + '"');
-      if (!files[file]) throw new Error('file "' + file + '" not found');
+      var filepath = metalsmith.dir + '/' + metalsmith._src + '/' + file;
+      var exists = fs.existsSync(filepath);
+      if (! exists) throw new Error('file "' + file + '" not found');
 
       var parse = parsers[ext];
       var str = files[file].contents.toString();


### PR DESCRIPTION
This lets the plugin work on Windows, where `files` keys use backslashes e.g. `"data\\global.yaml"`, but user assumes support for forward-slash node-style paths, e.g. `"data/global.yaml"`.
