### PR TITLE
Parse markdown in yaml metadata, if using .yamlmd extension, fixes #23

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -3,7 +3,7 @@
 
   A metalsmith plugin to load global metadata from files.
 
-  Supports `.json` and `.yaml` data.
+  Supports `.json` and `.yaml` data. Can also parse markdown in .yaml files with the .yamlmd extension, using `markdown-it`. 
 
 ## Installation
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,8 @@
 var path = require('path');
 var extname = path.extname;
 var yaml = require('js-yaml');
+var markdown = require('markdown-it')();
+var _ = require('lodash'); 
 
 /**
  * Expose `plugin`.
@@ -15,15 +17,15 @@ module.exports = plugin;
 var parsers = {
   '.json': JSON.parse,
   '.yaml': yaml.safeLoad,
-  '.yml': yaml.safeLoad
+  '.yml': yaml.safeLoad,
+  '.yamlmd': yaml.safeLoad
 };
 
-/**
- * Metalsmith plugin to hide drafts from the output.
- *
- * @param {Object} opts
- * @return {Function}
- */
+function deepMap(obj, iterator) {
+  return _.transform(obj, (result, val, key) => {
+    result[key] = _.isObject(val) ? deepMap(val, iterator) : iterator(val)
+  })
+}
 
 function plugin(opts){
   opts = opts || {};
@@ -47,6 +49,10 @@ function plugin(opts){
         } catch (e) {
           return done(new Error('malformed data in "' + file + '"'));
         }
+
+        if (ext == '.yamlmd') { 
+	  data = deepMap(data, (m) => markdown.renderInline(m))
+        } 
 
         metadata[key] = data;
       }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "license": "MIT",
   "main": "lib/index.js",
   "dependencies": {
-    "js-yaml": "^3.2.7"
+    "js-yaml": "^3.2.7",
+    "lodash": "^4.17.4",
+    "markdown-it": "^8.3.1"
   },
   "devDependencies": {
     "mocha": "^2.1.0",


### PR DESCRIPTION
You might consider this unnecessary, but it scratches an itch for me, since parsing markdown that appears in metadata is a little difficult in metalsmith otherwise. 